### PR TITLE
Sidebar+⌘K tag i18n, count badges, hide sparse tags; 100% zoom button

### DIFF
--- a/src/cmdk/CommandKClient.tsx
+++ b/src/cmdk/CommandKClient.tsx
@@ -422,7 +422,7 @@ export default function CommandKClient({
                   )}
                   aria-label={formatCountDescriptive(count)}
                 >
-                  <span aria-hidden>{count}</span>
+                  <span aria-hidden="true">{count}</span>
                 </span>
                 {isTagFavs(tag) &&
                   <IconFavs

--- a/src/cmdk/CommandKClient.tsx
+++ b/src/cmdk/CommandKClient.tsx
@@ -61,12 +61,12 @@ import {
   limitTagsByCount,
 } from '@/tag';
 import { formatCount, formatCountDescriptive } from '@/utility/string';
+import { zhForSlug } from '@/photo/ai/tagVocabulary';
 import CommandKItem from './CommandKItem';
 import {
   CATEGORY_VISIBILITY,
   COLOR_SORT_ENABLED,
   GRID_HOMEPAGE_ENABLED,
-  HIDE_TAGS_WITH_ONE_PHOTO,
   SHOW_ABOUT_PAGE,
 } from '@/app/config';
 import { DialogDescription, DialogTitle } from '@radix-ui/react-dialog';
@@ -111,6 +111,10 @@ const DIALOG_DESCRIPTION = 'For searching photos, views, and settings';
 const LISTENER_KEYDOWN = 'keydown';
 
 const MAX_HEIGHT = '20rem';
+
+// FORK: ⌘K tag list hides tags with fewer than this many photos (favs/private
+// and active-search matches are exempt — see limitTagsByCount).
+const CMDK_MIN_TAG_COUNT = 3;
 
 type CommandKItem = {
   label: ReactNode
@@ -301,8 +305,9 @@ export default function CommandKClient({
     } else {
       return [];
     }
-  },    
-  [photos],
+  },
+  // FORK: contentLanguage so photo titles re-translate on the EN/中 toggle.
+  [photos, contentLanguage],
   );
 
   useEffect(() => {
@@ -331,9 +336,11 @@ export default function CommandKClient({
     const tagsIncludingPrivate = photosCountHidden > 0
       ? addPrivateToTags(_tags, photosCountHidden)
       : _tags;
-    return HIDE_TAGS_WITH_ONE_PHOTO
-      ? limitTagsByCount(tagsIncludingPrivate, 2, queryFormatted)
-      : tagsIncludingPrivate;
+    // FORK: hide sparse tags (<3 photos) so the ⌘K list shows clustered facet
+    // tags, not subject singletons. Favs/private always show; a search query
+    // still surfaces a rare tag (queryToInclude in limitTagsByCount).
+    return limitTagsByCount(tagsIncludingPrivate, CMDK_MIN_TAG_COUNT,
+      queryFormatted);
   }, [_tags, photosCountHidden, queryFormatted]);
 
   const categorySections: CommandKSection[] = useMemo(() =>
@@ -400,7 +407,23 @@ export default function CommandKClient({
             items: tags.map(({ tag, count }) => ({
               explicitKey: formatTag(tag),
               label: <span className="flex items-center gap-[7px]">
-                {formatTag(tag)}
+                {/* FORK: zh label for facet tags (zhForSlug), en slug
+                    otherwise. Reserved favs/private keep their en form. */}
+                {contentLanguage === 'zh'
+                  && !isTagFavs(tag) && !isTagPrivate(tag)
+                  ? zhForSlug(tag) ?? formatTag(tag)
+                  : formatTag(tag)}
+                {/* FORK: inline per-tag count badge */}
+                <span
+                  className={clsx(
+                    'text-[11px] leading-none tabular-nums text-dim',
+                    'px-1.5 py-[3px] rounded-full',
+                    'bg-gray-100 dark:bg-gray-800/60',
+                  )}
+                  aria-label={formatCountDescriptive(count)}
+                >
+                  <span aria-hidden>{count}</span>
+                </span>
                 {isTagFavs(tag) &&
                   <IconFavs
                     size={13}
@@ -413,8 +436,6 @@ export default function CommandKClient({
                     className="text-dim translate-y-[-0.5px]"
                   />}
               </span>,
-              annotation: formatCount(count),
-              annotationAria: formatCountDescriptive(count),
               path: pathForTag(tag),
             })),
           };
@@ -465,6 +486,7 @@ export default function CommandKClient({
     recipes,
     films,
     focalLengths,
+    contentLanguage,
   ]);
 
   const clientSections: CommandKSection[] = [{

--- a/src/components/entity/EntityLink.tsx
+++ b/src/components/entity/EntityLink.tsx
@@ -25,6 +25,8 @@ export interface EntityLinkExternalProps {
   className?: string
   truncate?: boolean
   hoverCount?: number
+  // FORK: render the count as a persistent badge (not hover-only).
+  alwaysShowCount?: boolean
   hoverType?: 'auto' | 'text' | 'image' | 'none'
   hoverQueryOptions?: PhotoQueryOptions
 }
@@ -44,6 +46,7 @@ export default function EntityLink({
   path = '', // Make link optional for debugging purposes
   pathTarget,
   hoverCount = 0,
+  alwaysShowCount,
   hoverType = 'auto',
   hoverQueryOptions,
   prefetch,
@@ -104,7 +107,7 @@ export default function EntityLink({
     );
 
   const showHoverText =
-    canShowHover && (
+    canShowHover && !alwaysShowCount && (
       (hoverType === 'auto' && !SHOW_CATEGORY_IMAGE_HOVERS) ||
       hoverType === 'text'
     );
@@ -212,6 +215,15 @@ export default function EntityLink({
         </span>}
       {showHoverText &&
         <span className="hidden peer-hover:inline text-dim">
+          {hoverCount}
+        </span>}
+      {/* FORK: persistent per-item count badge (always shown, not on hover) */}
+      {alwaysShowCount && hoverCount > 0 &&
+        <span className={clsx(
+          'shrink-0 tabular-nums text-dim',
+          'text-[10px] leading-none px-1.5 py-[3px] rounded-full',
+          'bg-gray-100 dark:bg-gray-800/60',
+        )}>
           {hoverCount}
         </span>}
       {isLoading && !suppressSpinner &&

--- a/src/components/image/ZoomControls.tsx
+++ b/src/components/image/ZoomControls.tsx
@@ -39,9 +39,9 @@ export default function ZoomControls({
     if (ref) { ref.current = { open, zoomTo }; }
   }, [ref, open, zoomTo]);
 
-  // FORK: jump the fullscreen viewer to 100% — true actual-pixel detail of the
-  // R2 original (viewerjs ratio 1 = natural size). The toolbar's "1:1" control
-  // only resets to FIT, so this is the only way to inspect real detail.
+  // FORK: jump the fullscreen viewer to 100% — actual-pixel detail of the R2
+  // original (viewerjs ratio 1 = natural size). The toolbar's "1:1" only resets
+  // to FIT, so this button is the only way to inspect real detail.
   const button =
     <button
       type="button"

--- a/src/components/image/ZoomControls.tsx
+++ b/src/components/image/ZoomControls.tsx
@@ -2,7 +2,7 @@ import clsx from 'clsx/lite';
 import { ReactNode, RefObject, useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import useImageZoomControls from './useImageZoomControls';
-import { RiCollapseDiagonalLine, RiExpandDiagonalLine } from 'react-icons/ri';
+import { RiExpandDiagonalLine } from 'react-icons/ri';
 
 export type ZoomControlsRef = {
   open: () => void
@@ -28,9 +28,7 @@ export default function ZoomControls({
 
   const {
     open,
-    reset,
     zoomTo,
-    zoomLevel,
     refViewerContainer,
   } = useImageZoomControls({
     refImageContainer,
@@ -41,22 +39,24 @@ export default function ZoomControls({
     if (ref) { ref.current = { open, zoomTo }; }
   }, [ref, open, zoomTo]);
 
-  const shouldZoomTo2x = zoomLevel !== 2;
-
-  const button = 
+  // FORK: jump the fullscreen viewer to 100% — true actual-pixel detail of the
+  // R2 original (viewerjs ratio 1 = natural size). The toolbar's "1:1" control
+  // only resets to FIT, so this is the only way to inspect real detail.
+  const button =
     <button
       type="button"
+      aria-label="100%"
       className={clsx(
         'fixed top-[20px] right-[70px]',
-        'size-10 items-center justify-center',
-        'rounded-full border-none',
-        'text-white bg-black/50 hover:bg-black/85',
+        'h-10 px-3.5 flex items-center justify-center gap-1.5',
+        'rounded-full border-none cursor-pointer',
+        'text-white text-[13px] font-medium tabular-nums',
+        'bg-black/50 hover:bg-black/85',
       )}
-      onClick={() => shouldZoomTo2x ? zoomTo(2) : reset()}
+      onClick={() => zoomTo(1)}
     >
-      {shouldZoomTo2x
-        ? <RiCollapseDiagonalLine className="shrink-0" size={20} />
-        : <RiExpandDiagonalLine className="shrink-0" size={20} />}
+      <RiExpandDiagonalLine className="shrink-0" size={16} />
+      100%
     </button>;
 
   return (

--- a/src/components/image/useImageZoomControls.ts
+++ b/src/components/image/useImageZoomControls.ts
@@ -25,8 +25,6 @@ export default function useImageZoomControls({
 
   const { setShouldRespondToKeyboardCommands } = useAppState();
 
-  const [zoomLevel, setZoomLevel] = useState(1);
-
   const [colorLight, setColorLight] = useState<string>();
 
   useMetaThemeColor({ colorLight });
@@ -39,11 +37,6 @@ export default function useImageZoomControls({
 
   const zoomTo = useCallback((zoomLevel = 1) =>
     viewerRef.current?.zoomTo(zoomLevel), []);
-
-  const reset = useCallback(() => {
-    setZoomLevel(1);
-    viewerRef.current?.reset();
-  }, []);
 
   useEffect(() => {
     if (isEnabled) {
@@ -83,9 +76,6 @@ export default function useImageZoomControls({
           hidden: () => {
             setShouldRespondToKeyboardCommands?.(true);
           },
-          zoom: ({ detail: { ratio } }) => {
-            setZoomLevel(ratio);
-          },
         });
         return () => {
           viewerRef.current?.destroy();
@@ -104,9 +94,7 @@ export default function useImageZoomControls({
   return {
     open,
     close,
-    reset,
     zoomTo,
-    zoomLevel,
     refViewerContainer,
   };
 }

--- a/src/photo/PhotoGridSidebar.tsx
+++ b/src/photo/PhotoGridSidebar.tsx
@@ -15,10 +15,8 @@ import PhotoFavs from '../tag/PhotoFavs';
 import { useAppState } from '@/app/AppState';
 import { useMemo, useRef } from 'react';
 import PhotoPrivate from '@/tag/PhotoPrivate';
-import {
-  CATEGORY_VISIBILITY,
-  HIDE_TAGS_WITH_ONE_PHOTO,
-} from '@/app/config';
+import { CATEGORY_VISIBILITY } from '@/app/config';
+import { zhForSlug } from '@/photo/ai/tagVocabulary';
 import { clsx } from 'clsx/lite';
 import PhotoRecipe from '@/recipe/PhotoRecipe';
 import IconCamera from '@/components/icons/IconCamera';
@@ -45,6 +43,11 @@ import PhotoAlbum from '@/album/PhotoAlbum';
 const APPROXIMATE_ITEM_HEIGHT = 40;
 const ABOUT_HEIGHT_OFFSET = 24;
 
+// FORK: hide tags with fewer than this many photos from the sidebar, so it
+// shows clustered facet tags rather than subject singletons (favs/private are
+// exempt in limitTagsByCount).
+const MIN_TAG_COUNT = 3;
+
 export default function PhotoGridSidebar({
   photosCount,
   containerHeight,
@@ -59,13 +62,10 @@ export default function PhotoGridSidebar({
   aboutTextHasBrParagraphBreaks?: boolean
   className?: string
 }) {
-  const categories = useMemo(() => HIDE_TAGS_WITH_ONE_PHOTO
-    ? {
-      ..._categories,
-      tags: limitTagsByCount(_categories.tags, 2),
-    }
-    : _categories
-  , [_categories]);
+  const categories = useMemo(() => ({
+    ..._categories,
+    tags: limitTagsByCount(_categories.tags, MIN_TAG_COUNT),
+  }), [_categories]);
 
   const {
     recents,
@@ -102,7 +102,7 @@ export default function PhotoGridSidebar({
     )
     : undefined;
 
-  const { photosCountHidden } = useAppState();
+  const { photosCountHidden, contentLanguage } = useAppState();
 
   const tagsIncludingHidden = useMemo(() =>
     addPrivateToTags(tags, photosCountHidden)
@@ -250,7 +250,13 @@ export default function PhotoGridSidebar({
               return <PhotoTag
                 key={tag}
                 tag={tag}
+                // FORK: zh label for facet tags on the 中 toggle; en slug
+                // otherwise. Plus a persistent count badge (not hover-only).
+                displayLabel={contentLanguage === 'zh'
+                  ? zhForSlug(tag)
+                  : undefined}
                 hoverCount={count}
+                alwaysShowCount
                 type="text-only"
                 prefetch={false}
                 contrast="low"


### PR DESCRIPTION
Follow-up polish on the live grid sidebar + viewer.

## Grid category sidebar (PhotoGridSidebar — the reported surface)
- **Tag labels localize** on the EN/中 toggle (`zhForSlug` facet labels via PhotoTag `displayLabel`; en slug otherwise). Verified on preview: `均衡 / 漫射光 / 宁静 / 夜晚` + headers `最近 / 标签 / 更多`.
- **Persistent count badge** per tag (new `EntityLink.alwaysShowCount` — was hover-only): `BALANCED 23 · DIFFUSED 19 · SERENE 16 · NIGHT 14`. Opt-in, so cameras/lenses/etc. are unchanged.
- **Hide tags with < 3 photos** always (`MIN_TAG_COUNT`), so only clustered facet tags show — not subject singletons. Favs/private exempt.

## ⌘K palette (parallel, consistent)
Same three: zh facet labels, inline count badge, hide-<3.

## Fullscreen viewer
- New **100%** button → true actual-pixel detail of the R2 original (viewerjs ratio 1). The toolbar `1:1` only resets to fit. Browser-verified locally.
- Cleaned up orphaned `zoomLevel`/`reset` state in `useImageZoomControls` (the new button removed their only consumer).

## Verification
- jest 24 suites / 118 tests · `npm run build` exit 0 · lint clean
- code-reviewer: **APPROVE** (no CRITICAL/HIGH; LOW/NIT fixed)
- Browser-verified on the preview deploy (sidebar, real data) + locally (zoom)

🤖 Generated with [Claude Code](https://claude.com/claude-code)