### PR TITLE
Localize free-form subject tags (surface tag_zh)

### DIFF
--- a/src/cmdk/CommandKClient.tsx
+++ b/src/cmdk/CommandKClient.tsx
@@ -404,14 +404,14 @@ export default function CommandKClient({
               size={13}
               className="translate-x-[1px] translate-y-[0.75px]"
             />,
-            items: tags.map(({ tag, count }) => ({
+            items: tags.map(({ tag, count, tagZh }) => ({
               explicitKey: formatTag(tag),
               label: <span className="flex items-center gap-[7px]">
-                {/* FORK: zh label for facet tags (zhForSlug), en slug
-                    otherwise. Reserved favs/private keep their en form. */}
+                {/* FORK: zh label — vocabulary zh for facets, model zh (tagZh)
+                    for subjects; en slug if neither. Favs/private stay en. */}
                 {contentLanguage === 'zh'
                   && !isTagFavs(tag) && !isTagPrivate(tag)
-                  ? zhForSlug(tag) ?? formatTag(tag)
+                  ? zhForSlug(tag) ?? tagZh ?? formatTag(tag)
                   : formatTag(tag)}
                 {/* FORK: inline per-tag count badge */}
                 <span

--- a/src/photo/PhotoGridSidebar.tsx
+++ b/src/photo/PhotoGridSidebar.tsx
@@ -227,7 +227,7 @@ export default function PhotoGridSidebar({
       />}
       maxItems={maxItemsPerCategory}
       items={tagsIncludingHidden
-        .map(({ tag, count }) => {
+        .map(({ tag, count, tagZh }) => {
           switch (tag) {
             case TAG_FAVS:
               return <PhotoFavs
@@ -250,10 +250,11 @@ export default function PhotoGridSidebar({
               return <PhotoTag
                 key={tag}
                 tag={tag}
-                // FORK: zh label for facet tags on the 中 toggle; en slug
-                // otherwise. Plus a persistent count badge (not hover-only).
+                // FORK: zh label on the 中 toggle — vocabulary zh for facet
+                // tags, model zh (tagZh) for free-form subject tags; en slug
+                // if neither. Plus a persistent count badge (not hover-only).
                 displayLabel={contentLanguage === 'zh'
-                  ? zhForSlug(tag)
+                  ? zhForSlug(tag) ?? tagZh
                   : undefined}
                 hoverCount={count}
                 alwaysShowCount

--- a/src/photo/query.ts
+++ b/src/photo/query.ts
@@ -307,19 +307,29 @@ export const getUniqueLenses = async () =>
   , 'getUniqueLenses');
 
 export const getUniqueTags = async (includeHidden?: boolean) =>
+  // FORK: also surface each tag's zh label by zipping tags + tags_zh (parallel
+  // unnest, NULL-padded). Facet tags carry their vocabulary zh; free-form
+  // subject tags carry the model-generated zh — so the sidebar/⌘K can localize
+  // EVERY tag on the 中 toggle, not just the controlled vocabulary.
   safelyQuery(() => query(`
-    SELECT DISTINCT unnest(tags) as tag,
+    SELECT t.tag,
       COUNT(*),
-      MAX(updated_at) as last_modified
-    FROM photos
-    ${includeHidden ? '' : 'WHERE hidden IS NOT TRUE'}
-    GROUP BY tag
-    ORDER BY tag ASC
-  `).then(({ rows }): Tags => rows.map(({ tag, count, last_modified }) => ({
-    tag,
-    count: parseInt(count, 10),
-    lastModified: last_modified as Date,
-  })))
+      MAX(p.updated_at) as last_modified,
+      MAX(t.tag_zh) as tag_zh
+    FROM photos p
+      CROSS JOIN LATERAL unnest(
+        p.tags, COALESCE(p.tags_zh, '{}'::varchar[])
+      ) AS t(tag, tag_zh)
+    ${includeHidden ? '' : 'WHERE p.hidden IS NOT TRUE'}
+    GROUP BY t.tag
+    ORDER BY t.tag ASC
+  `).then(({ rows }): Tags =>
+    rows.map(({ tag, count, last_modified, tag_zh }) => ({
+      tag,
+      count: parseInt(count, 10),
+      lastModified: last_modified as Date,
+      ...(tag_zh && tag_zh !== tag && { tagZh: tag_zh as string }),
+    })))
   , 'getUniqueTags');
 
 export const getUniqueRecipes = async () =>

--- a/src/tag/index.ts
+++ b/src/tag/index.ts
@@ -23,7 +23,9 @@ import { tagDisplayRank } from '@/photo/ai/tagVocabulary';
 export const TAG_FAVS     = 'favs';
 export const TAG_PRIVATE  = 'private';
 
-type TagWithMeta = { tag: string } & CategoryQueryMeta;
+// FORK: tagZh = the tag's localized (zh) display label, surfaced by
+// getUniqueTags (vocabulary zh for facets, model zh for free-form subjects).
+type TagWithMeta = { tag: string, tagZh?: string } & CategoryQueryMeta;
 
 export type Tags = TagWithMeta[]
 


### PR DESCRIPTION
Fixes the mixed EN/中 tag list: facet tags translated but free-form **subject** tags (deer/cat/ocean/mountains/aurora/musician/streetlights) stayed English — they aren't in the controlled vocabulary, but their zh exists per-photo in `tags_zh`.

- `getUniqueTags` now zips `tags` + `tags_zh` (parallel NULL-padded unnest) → returns a `tagZh` per tag (vocabulary zh for facets, model zh for subjects). COUNT unchanged (verified vs prod data).
- Sidebar + ⌘K label = `zhForSlug(tag) ?? tagZh ?? en-slug`.

**Verified on preview (中):** 猫 · 音乐家 · 海洋 · 路灯 · 群山 · 极光 — every tag localizes.

Gate: jest 24 suites/118 tests · build exit 0 · lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)